### PR TITLE
run prebuild steps for package scripts and avoid dmg/deb on non-mac/non-debian hosts

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "electron:preview:dev": "cross-env NODE_ENV=development electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
-    "package-win": "electron-builder --win",
-    "package-mac": "electron-builder --mac",
-    "package-linux": "electron-builder --linux",
+    "package-win": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.preload.json && cross-env NODE_ENV=production ELECTRON=true vite build && electron-builder --win",
+    "package-mac": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.preload.json && cross-env NODE_ENV=production ELECTRON=true vite build && electron-builder --mac",
+    "package-linux": "npx tsc -p tsconfig.electron.json && npx tsc -p tsconfig.preload.json && cross-env NODE_ENV=production ELECTRON=true vite build && electron-builder --linux",
     "postinstall": "electron-builder install-app-deps"
   },
   "dependencies": {
@@ -121,10 +121,6 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "target": [
         {
-          "target": "dmg",
-          "arch": ["x64", "arm64", "universal"]
-        },
-        {
           "target": "zip",
           "arch": ["x64", "arm64", "universal"]
         }
@@ -154,8 +150,7 @@
     },
     "linux": {
       "target": [
-        "AppImage",
-        "deb"
+        "AppImage"
       ],
       "icon": "./icons/png/favicon.png",
       "category": "Utility",


### PR DESCRIPTION
this change ensures:
package-win/package-mac/package-linux run the same pre-build steps (tsc for electron & preload + vite build) before electron-builder, matching electron:build, and

removes dmg from mac targets and deb from linux default targets so local builds (and non-mac CI) don’t fail because of missing dmg-builder/dmg-license or fpm cached binary. .dmg and .deb can still be built on appropriate runners with the required tools installed

had issues building otherwise..

package-linux
```bash
❯ npm run package-linux

> ai-gate@4.0.2 package-linux
> electron-builder --linux

  • electron-builder  version=25.1.8 os=6.17.1-cachyos
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=release-builds/builder-effective-config.yaml
  • executing @electron/rebuild  electronVersion=34.5.8 arch=x64 buildFromSource=false appDir=./
  • installing native dependencies  arch=x64
  • completed installing native dependencies
  • packaging       platform=linux arch=x64 electron=34.5.8 appOutDir=release-builds/linux-unpacked
  ⨯ Application entry file "dist-electron/main.js" in the "/home/floory/.git-projects/ai-gate-newer/release-builds/linux-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.  failedTask=build stackTrace=Error: Application entry file "dist-electron/main.js" in the "/home/floory/.git-projects/ai-gate-newer/release-builds/linux-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.
    at error (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/asar/asarFileChecker.ts:7:12)
    at checkFileInArchive (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/asar/asarFileChecker.ts:31:11)
    at LinuxPackager.checkFileInPackage (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:527:7)
    at LinuxPackager.sanityCheckPackage (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:575:5)
    at LinuxPackager.doPack (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:329:5)
    at LinuxPackager.pack (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:138:5)
    at Packager.doBuild (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/packager.ts:459:9)
    at executeFinally (/home/floory/.git-projects/ai-gate-newer/node_modules/builder-util/src/promise.ts:12:14)
    at Packager.build (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/packager.ts:393:31)
    at executeFinally (/home/floory/.git-projects/ai-gate-newer/node_modules/builder-util/src/promise.ts:12:14)
```

package-mac
```bash
❯ npm run package-mac

> ai-gate@4.0.1 package-mac
> electron-builder --mac

  • electron-builder  version=25.1.8 os=6.17.1-cachyos
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=release-builds/builder-effective-config.yaml
  ⨯ Cannot find module 'dmg-license'
Require stack:
- /home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/out/dmgLicense.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/out/dmg.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/out/dmgUtil.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/out/macPackager.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/out/index.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/electron-builder/out/builder.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/electron-builder/out/cli/cli.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/electron-builder/cli.js  failedTask=build stackTrace=Error: Cannot find module 'dmg-license'
Require stack:
- /home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/out/dmgLicense.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/out/dmg.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/out/dmgUtil.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/out/macPackager.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/out/index.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/electron-builder/out/builder.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/electron-builder/out/cli/cli.js
- /home/floory/.git-projects/ai-gate-newer/node_modules/electron-builder/cli.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)
    at Function._load (node:internal/modules/cjs/loader:1192:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
    at Module.require (node:internal/modules/cjs/loader:1463:12)
    at require (node:internal/modules/helpers:147:16)
    at Object.<anonymous> (/home/floory/.git-projects/ai-gate-newer/node_modules/dmg-builder/src/dmgLicense.ts:7:1)
    at Module._compile (node:internal/modules/cjs/loader:1706:14)
    at Object..js (node:internal/modules/cjs/loader:1839:10)
    at Module.load (node:internal/modules/cjs/loader:1441:32)
    at Function._load (node:internal/modules/cjs/loader:1263:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
    at Module.require (node:internal/modules/cjs/loader:1463:12)
```

package-win
```bash
❯ npm run package-win

> ai-gate@4.0.1 package-win
> electron-builder --win

  • electron-builder  version=25.1.8 os=6.17.1-cachyos
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=release-builds/builder-effective-config.yaml
  • executing @electron/rebuild  electronVersion=34.5.8 arch=x64 buildFromSource=false appDir=./
  • installing native dependencies  arch=x64
  • completed installing native dependencies
  • packaging       platform=win32 arch=x64 electron=34.5.8 appOutDir=release-builds/win-unpacked
  • updating asar integrity executable resource  executablePath=release-builds/win-unpacked/AI Gate.exe
  ⨯ Application entry file "dist-electron/main.js" in the "/home/floory/.git-projects/ai-gate-newer/release-builds/win-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.  failedTask=build stackTrace=Error: Application entry file "dist-electron/main.js" in the "/home/floory/.git-projects/ai-gate-newer/release-builds/win-unpacked/resources/app.asar" does not exist. Seems like a wrong configuration.
    at error (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/asar/asarFileChecker.ts:7:12)
    at checkFileInArchive (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/asar/asarFileChecker.ts:31:11)
    at WinPackager.checkFileInPackage (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:527:7)
    at WinPackager.sanityCheckPackage (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:575:5)
    at WinPackager.doPack (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:329:5)
    at WinPackager.pack (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/platformPackager.ts:138:5)
    at Packager.doBuild (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/packager.ts:459:9)
    at executeFinally (/home/floory/.git-projects/ai-gate-newer/node_modules/builder-util/src/promise.ts:12:14)
    at Packager.build (/home/floory/.git-projects/ai-gate-newer/node_modules/app-builder-lib/src/packager.ts:393:31)
    at executeFinally (/home/floory/.git-projects/ai-gate-newer/node_modules/builder-util/src/promise.ts:12:14)
```