### PR TITLE
Add browser zoom, tab numbers, and provider webview polish

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+  <key>com.apple.security.device.camera</key>
+  <true/>
+</dict>
+</plist>

--- a/e2e/shortcuts/panes.spec.ts
+++ b/e2e/shortcuts/panes.spec.ts
@@ -76,6 +76,28 @@ test('tab number setting prefixes tabs by visible order', async ({ appPage }) =>
   await expect(tabsInPanel(appPage, 0).nth(1)).toContainText('2:');
 });
 
+test('browser zoom shortcut dispatches to the active tab', async ({ appPage }) => {
+  await focusPanel(appPage, 0);
+  const activeTabId = await activeTabInPanel(appPage, 0).getAttribute('data-testid');
+  const activeInstanceId = activeTabId?.replace(/^tab-/, '');
+  expect(activeInstanceId).toBeTruthy();
+
+  await appPage.evaluate(() => {
+    (window as any).__zoomEvents = [];
+    window.addEventListener('ai-gate-webview-zoom', ((event: Event) => {
+      (window as any).__zoomEvents.push((event as CustomEvent).detail);
+    }) as EventListener);
+  });
+
+  await appPage.keyboard.down(primaryKey());
+  await appPage.keyboard.press('=');
+  await appPage.keyboard.up(primaryKey());
+
+  await expect.poll(() => appPage.evaluate(() => (window as any).__zoomEvents)).toEqual([
+    { instanceId: activeInstanceId, action: 'in' },
+  ]);
+});
+
 test('tmux prefix x closes the active pane tab', async ({ appPage }) => {
   await applyTmuxPreset(appPage);
   await createToolInPanel(appPage, 0, 'gemini');

--- a/e2e/shortcuts/panes.spec.ts
+++ b/e2e/shortcuts/panes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../fixtures/electronApp';
-import { activeTabInPanel, createToolInPanel, focusPanel, isWindowVisible, tabCount } from '../support/app';
+import { activeTabInPanel, createToolInPanel, focusPanel, isWindowVisible, tabCount, tabsInPanel } from '../support/app';
 import { applyItermPreset, applyTmuxPreset, pressPrefix, primaryKey } from '../support/shortcuts';
 
 test('iTerm direct tab shortcut switches to the intended tab', async ({ appPage }) => {
@@ -49,6 +49,31 @@ test('primary W closes an app tab and keeps the Electron window visible', async 
   await expect.poll(() => tabCount(appPage, 0)).toBe(1);
   await expect(activeTabInPanel(appPage, 0)).toHaveAttribute('data-tool-id', 'chatgpt');
   await expect.poll(() => isWindowVisible(appPage)).toBe(true);
+});
+
+test('closing the active middle tab selects the next adjacent tab', async ({ appPage }) => {
+  await applyTmuxPreset(appPage);
+  await createToolInPanel(appPage, 0, 'gemini');
+  await focusPanel(appPage, 0);
+  await pressPrefix(appPage, `${primaryKey()}+N`, '3');
+  await tabsInPanel(appPage, 0).nth(1).click();
+  await expect(activeTabInPanel(appPage, 0)).toHaveAttribute('data-tool-id', 'gemini');
+
+  await focusPanel(appPage, 0);
+  await pressPrefix(appPage, `${primaryKey()}+B`, 'x');
+
+  await expect.poll(() => tabCount(appPage, 0)).toBe(2);
+  await expect(activeTabInPanel(appPage, 0)).toHaveAttribute('data-tool-id', 'perplexity');
+});
+
+test('tab number setting prefixes tabs by visible order', async ({ appPage }) => {
+  await appPage.getByTestId('settings-button').click();
+  await appPage.getByLabel('Show numbers before tabs').click();
+  await appPage.getByRole('button', { name: /save settings/i }).click();
+
+  await expect(tabsInPanel(appPage, 0).nth(0)).toContainText('1:');
+  await createToolInPanel(appPage, 0, 'gemini');
+  await expect(tabsInPanel(appPage, 0).nth(1)).toContainText('2:');
 });
 
 test('tmux prefix x closes the active pane tab', async ({ appPage }) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -69,6 +69,9 @@ const codeKeyLabels = new Map([
   ['Backquote', '`'],
   ['Minus', '-'],
   ['Equal', '='],
+  ['NumpadAdd', '+'],
+  ['NumpadSubtract', '-'],
+  ['NumpadEqual', '='],
   ['BracketLeft', '['],
   ['BracketRight', ']'],
   ['Backslash', '\\'],
@@ -113,6 +116,17 @@ const shortcutKeyFromInput = (input: any) => {
 /** Returns true when a key label is a shortcut modifier. */
 const isShortcutModifier = (key: string) => {
   return ['Mod', 'Ctrl', 'Meta', 'Alt', 'Shift'].includes(normalizeShortcutKey(key));
+};
+
+/** Returns the browser zoom shortcut id for Electron input, if any. */
+const getBrowserZoomShortcutIdFromInput = (input: any) => {
+  const inputKey = shortcutKeyFromInput(input);
+  const isPrimary = (!!input.control || !!input.meta) && !input.alt;
+  if (!isPrimary) return null;
+  if (inputKey === '=' || inputKey === '+') return 'browser-zoom-in';
+  if (!input.shift && inputKey === '-') return 'browser-zoom-out';
+  if (!input.shift && inputKey === '0') return 'browser-zoom-reset';
+  return null;
 };
 
 /** Checks whether Electron input matches a stored shortcut combo. */
@@ -174,6 +188,13 @@ const handleShortcutInput = (event: any, input: any) => {
   if (global.shortcutRecordingActive) return;
 
   const key = normalizeShortcutKey(input.key || '');
+  const browserZoomShortcutId = getBrowserZoomShortcutIdFromInput(input);
+  if (browserZoomShortcutId) {
+    event.preventDefault();
+    sendShortcutPayload({ type: 'action', shortcutId: browserZoomShortcutId });
+    return;
+  }
+
   const isPrimaryOnly = (!!input.control || !!input.meta) && !input.shift && !input.alt;
   const isPrimaryShift = (!!input.control || !!input.meta) && !!input.shift && !input.alt;
   const shouldNeutralizeNativeClose = key === 'w' && (isPrimaryOnly || isPrimaryShift);
@@ -687,17 +708,8 @@ app.on('window-all-closed', () => {
   // On Windows and Linux, keep the app running in the system tray
 });
 
-// Prevent the app from quitting when all windows are closed
-app.on('before-quit', (event: any) => {
-  // Only allow quitting if explicitly requested from tray menu
-  if (!isE2E && !global.isQuiting) {
-    event.preventDefault();
-    // Hide the window instead of quitting
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.hide();
-    }
-    return false;
-  }
+app.on('before-quit', () => {
+  global.isQuiting = true;
 });
 
 app.on('activate', () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, session, shell, Menu, Tray, nativeImage, ipcMain } = require('electron');
+const { app, BrowserWindow, session, shell, Menu, Tray, nativeImage, ipcMain, systemPreferences } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { exec } = require('child_process');
@@ -33,6 +33,8 @@ if (!gotSingleInstanceLock) {
 // Global variables for tray and window
 let mainWindow: any = null;
 let tray: any = null;
+let providerContextMenu: any = null;
+const pendingNativeMediaAccessRequests = new Map<string, Promise<boolean>>();
 
 type ShortcutMode = 'standard' | 'prefix';
 type KeyCombo = string[];
@@ -86,6 +88,143 @@ const codeKeyLabels = new Map([
 /** Returns true when a provider webview should be allowed to open an in-app auth popup. */
 const isProviderAuthPopupUrl = (url: string) => {
   return /^https:\/\/accounts\.google\.com\//i.test(url);
+};
+
+/** Loads the ESM-only provider context-menu helper from the CommonJS main bundle. */
+const loadProviderContextMenu = async () => {
+  const dynamicImport = new Function('specifier', 'return import(specifier)');
+  const module = await dynamicImport('electron-context-menu');
+  return module.default;
+};
+
+/** Returns true when a URL can safely make normal web permission requests. */
+const isHttpUrl = (url: string) => {
+  return /^https?:\/\//i.test(url);
+};
+
+/** Returns the best origin URL from an Electron permission details payload. */
+const getPermissionRequestUrl = (details: any) => {
+  return details?.requestingUrl || details?.securityOrigin || details?.embeddingOrigin || '';
+};
+
+/** Returns a normalized origin string for an Electron permission request. */
+const getPermissionOrigin = (url: string) => {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '';
+  }
+};
+
+/** Returns true when an Electron permission name represents media capture. */
+const isMediaPermission = (permission: string) => {
+  return ['media', 'audioCapture', 'videoCapture', 'microphone', 'camera'].includes(permission);
+};
+
+/** Returns the native macOS media types implied by an Electron permission request. */
+const getNativeMediaTypes = (permission: string, details: any): Array<'microphone' | 'camera'> => {
+  const mediaTypes = new Set<'microphone' | 'camera'>();
+  const requestedTypes = details?.mediaTypes || [];
+
+  if (permission === 'audioCapture' || permission === 'microphone' || requestedTypes.includes('audio') || details?.mediaType === 'audio') {
+    mediaTypes.add('microphone');
+  }
+  if (permission === 'videoCapture' || permission === 'camera' || requestedTypes.includes('video') || details?.mediaType === 'video') {
+    mediaTypes.add('camera');
+  }
+  if (mediaTypes.size === 0) mediaTypes.add('microphone');
+
+  return [...mediaTypes];
+};
+
+/** Returns true when native macOS microphone/camera access is already granted. */
+const hasNativeMediaAccess = (mediaTypes: Array<'microphone' | 'camera'>) => {
+  if (process.platform !== 'darwin') return true;
+  const statuses = mediaTypes.map(mediaType => ({
+    mediaType,
+    status: systemPreferences.getMediaAccessStatus(mediaType),
+  }));
+  return statuses.every(item => item.status === 'granted');
+};
+
+/** Requests one native macOS media permission with in-flight de-duplication. */
+const requestNativeMediaTypeAccess = (mediaType: 'microphone' | 'camera') => {
+  if (process.platform !== 'darwin') return Promise.resolve(true);
+
+  const status = systemPreferences.getMediaAccessStatus(mediaType);
+  if (status === 'granted') return Promise.resolve(true);
+  if (status === 'denied' || status === 'restricted') return Promise.resolve(false);
+
+  const pendingRequest = pendingNativeMediaAccessRequests.get(mediaType);
+  if (pendingRequest) return pendingRequest;
+
+  const request = systemPreferences.askForMediaAccess(mediaType)
+    .finally(() => pendingNativeMediaAccessRequests.delete(mediaType));
+  pendingNativeMediaAccessRequests.set(mediaType, request);
+  return request;
+};
+
+/** Requests any missing native macOS microphone/camera permission. */
+const requestNativeMediaAccess = async (mediaTypes: Array<'microphone' | 'camera'>) => {
+  if (process.platform !== 'darwin') return true;
+
+  for (const mediaType of mediaTypes) {
+    const granted = await requestNativeMediaTypeAccess(mediaType);
+    if (!granted) return false;
+  }
+
+  return true;
+};
+
+/** Configures persistent provider webviews to allow browser media prompts. */
+const configureProviderPermissions = (providerSession: any) => {
+  providerSession.setPermissionCheckHandler((_webContents: any, permission: string, requestingOrigin: string, details: any) => {
+    if (!isMediaPermission(permission)) return false;
+
+    const requestUrl = requestingOrigin || getPermissionRequestUrl(details);
+    const origin = getPermissionOrigin(requestUrl);
+    const mediaTypes = getNativeMediaTypes(permission, details);
+    const result = isHttpUrl(requestUrl) && !!origin && hasNativeMediaAccess(mediaTypes);
+    return result;
+  });
+
+  providerSession.setPermissionRequestHandler((_webContents: any, permission: string, callback: (granted: boolean) => void, details: any) => {
+    if (!isMediaPermission(permission)) {
+      callback(false);
+      return;
+    }
+
+    const requestUrl = getPermissionRequestUrl(details);
+    const origin = getPermissionOrigin(requestUrl);
+    const mediaTypes = getNativeMediaTypes(permission, details);
+
+    if (!isHttpUrl(requestUrl) || !origin) {
+      callback(false);
+      return;
+    }
+
+    requestNativeMediaAccess(mediaTypes)
+      .then(granted => callback(granted))
+      .catch(() => callback(false));
+  });
+};
+
+/** Installs a browser-like context menu for one provider webview. */
+const installProviderContextMenu = (contents: any) => {
+  if (contents.getType?.() !== 'webview' || !providerContextMenu) return;
+  providerContextMenu({
+    window: contents,
+    showSelectAll: true,
+    showCopyImageAddress: true,
+    showCopyVideoAddress: true,
+    showSaveImage: false,
+    showSaveImageAs: false,
+    showSaveVideo: false,
+    showSaveVideoAs: false,
+    showSaveLinkAs: false,
+    showServices: process.platform === 'darwin',
+    showInspectElement: isDevelopment,
+  });
 };
 
 // Keep this local copy paired with src/lib/shortcutUtils.ts. The main process
@@ -341,6 +480,7 @@ function createWindow() {
       allowRunningInsecureContent: false,
       devTools: false,
       nativeWindowOpen: true,
+      spellcheck: true,
       preload: path.join(__dirname, 'preload.js'),
       // backgroundThrottling: false
     }
@@ -420,8 +560,8 @@ function createWindow() {
     callback({ responseHeaders: details.responseHeaders });
   });
   
-  // Create a persistent session for webviews to retain logins
-  session.fromPartition('persist:webtool');
+  // Create a persistent session for webviews to retain logins and permissions
+  configureProviderPermissions(session.fromPartition('persist:webtool'));
 
   // Handle window events
   mainWindow.on('close', (event: any) => {
@@ -660,13 +800,16 @@ ipcMain.on('set-shortcut-recording-active', (_event: any, isActive: boolean) => 
   if (isActive) clearShortcutPrefix();
 });
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  providerContextMenu = await loadProviderContextMenu();
+
   // Register the web-contents listener BEFORE createWindow so it catches the
   // main BrowserWindow's webContents (created synchronously inside createWindow).
   app.on('web-contents-created', (_: any, contents: any) => {
     contents.on('before-input-event', (event: any, input: any) => {
       handleShortcutInput(event, input);
     });
+    installProviderContextMenu(contents);
 
     // For all web contents (including webviews)
     // Open all window.open() calls in external browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@tailwindcss/typography": "^0.5.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "electron-context-menu": "^4.1.2",
         "electron-updater": "^6.6.2",
         "lucide-react": "^0.475.0",
         "react": "^19.0.0",
@@ -5627,11 +5628,150 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/electron-context-menu": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-4.1.2.tgz",
+      "integrity": "sha512-9xYTUV0oRqKL50N9W71IrXNdVRB0LuBp3R1zkUdUc2wfIa2/QZwYYj5RLuO7Tn7ZSLVIaO3X6u+EIBK+cBvzrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^4.0.0",
+        "electron-dl": "^4.0.0",
+        "electron-is-dev": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/electron-context-menu/node_modules/is-fullwidth-code-point": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/electron-context-menu/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/electron-dl": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/electron-dl/-/electron-dl-4.0.0.tgz",
+      "integrity": "sha512-USiB9816d2JzKv0LiSbreRfTg5lDk3lWh0vlx/gugCO92ZIJkHVH0UM18EHvKeadErP6Xn4yiTphWzYfbA2Ong==",
+      "license": "MIT",
+      "dependencies": {
+        "ext-name": "^5.0.0",
+        "pupa": "^3.1.0",
+        "unused-filename": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/electron-is-dev": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-3.0.1.tgz",
       "integrity": "sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5952,6 +6092,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-goat": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-4.0.0.tgz",
+      "integrity": "sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -6172,6 +6324,31 @@
       "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.28.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ext-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -6539,6 +6716,18 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -8808,7 +8997,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9850,6 +10038,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/pupa": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-3.3.0.tgz",
+      "integrity": "sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-goat": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10639,6 +10842,39 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
+      "license": "MIT",
+      "dependencies": {
+        "sort-keys": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-keys/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map": {
@@ -11508,6 +11744,43 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unused-filename": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/unused-filename/-/unused-filename-4.0.1.tgz",
+      "integrity": "sha512-ZX6U1J04K1FoSUeoX1OicAhw4d0aro2qo+L8RhJkiGTNtBNkd/Fi1Wxoc9HzcVu6HfOzm0si/N15JjxFmD1z6A==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^5.0.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unused-filename/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unused-filename/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@tailwindcss/typography": "^0.5.16",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-context-menu": "^4.1.2",
     "electron-updater": "^6.6.2",
     "lucide-react": "^0.475.0",
     "react": "^19.0.0",
@@ -128,6 +129,10 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "AI Gate needs microphone access when an AI provider requests voice input.",
+        "NSCameraUsageDescription": "AI Gate needs camera access when an AI provider requests video input."
+      },
       "target": [
         {
           "target": "dmg",

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -57,6 +57,7 @@ export const SettingsPanel = ({ isCollapsed = false }: SettingsPanelProps) => {
     defaultTools: settings.defaultTools || [],
     autoLayout: settings.autoLayout ?? true,
     syncedTabs: settings.syncedTabs ?? false,
+    showTabNumbers: settings.showTabNumbers ?? false,
   });
   
   useEffect(() => {
@@ -66,6 +67,7 @@ export const SettingsPanel = ({ isCollapsed = false }: SettingsPanelProps) => {
       defaultTools: settings.defaultTools || [],
       autoLayout: settings.autoLayout ?? true,
       syncedTabs: settings.syncedTabs ?? false,
+      showTabNumbers: settings.showTabNumbers ?? false,
     });
   }, [settings, open]);
   
@@ -86,6 +88,7 @@ export const SettingsPanel = ({ isCollapsed = false }: SettingsPanelProps) => {
       defaultTools: tempSettings.defaultTools,
       autoLayout: tempSettings.autoLayout,
       syncedTabs: tempSettings.syncedTabs,
+      showTabNumbers: tempSettings.showTabNumbers,
     });
 
     toast({
@@ -218,6 +221,25 @@ export const SettingsPanel = ({ isCollapsed = false }: SettingsPanelProps) => {
                     id="syncedTabs"
                     checked={tempSettings.syncedTabs}
                     onCheckedChange={(checked) => setTempSettings(prev => ({ ...prev, syncedTabs: checked }))}
+                  />
+                </div>
+              </div>
+
+              <Separator />
+
+              <div className="space-y-4">
+                <h3 className="text-sm font-medium">Tab Numbers</h3>
+                <div className="flex items-center justify-between">
+                  <div className="space-y-1">
+                    <Label htmlFor="showTabNumbers">Show numbers before tabs</Label>
+                    <p className="text-xs text-muted-foreground">
+                      Display tab positions as 1:, 2:, and 3: in the tab bar.
+                    </p>
+                  </div>
+                  <Switch
+                    id="showTabNumbers"
+                    checked={tempSettings.showTabNumbers}
+                    onCheckedChange={(checked) => setTempSettings(prev => ({ ...prev, showTabNumbers: checked }))}
                   />
                 </div>
               </div>

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -233,7 +233,7 @@ export const SettingsPanel = ({ isCollapsed = false }: SettingsPanelProps) => {
                   <div className="space-y-1">
                     <Label htmlFor="showTabNumbers">Show numbers before tabs</Label>
                     <p className="text-xs text-muted-foreground">
-                      Display tab positions as 1:, 2:, and 3: in the tab bar.
+                      Prefix each tab with its position in the panel.
                     </p>
                   </div>
                   <Switch

--- a/src/components/workspace/AIToolView.tsx
+++ b/src/components/workspace/AIToolView.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { useRef, useEffect, useState } from 'react';
 import { useAITools } from '@/context/AIToolsContext';
+import { getNextWebviewZoomFactor, WEBVIEW_ZOOM_EVENT, type WebviewZoomAction } from '@/lib/webviewZoom';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,6 +56,23 @@ export const AIToolView = ({ tool, instance, isVisible, panelId }: AIToolViewPro
       hasSetSrcRef.current = true;
     }
   }, [isVisible, instance.state.lastUrl, tool.url]);
+
+  useEffect(() => {
+    /** Applies a browser zoom command when this view owns the active instance. */
+    const handleWebviewZoom = (event: Event) => {
+      const detail = (event as CustomEvent<{ instanceId: string; action: WebviewZoomAction }>).detail;
+      if (!detail || detail.instanceId !== instance.id) return;
+
+      const webview = webviewRef.current as any;
+      if (!webview || typeof webview.setZoomFactor !== 'function') return;
+
+      const currentZoom = typeof webview.getZoomFactor === 'function' ? webview.getZoomFactor() : 1;
+      webview.setZoomFactor(getNextWebviewZoomFactor(currentZoom, detail.action));
+    };
+
+    window.addEventListener(WEBVIEW_ZOOM_EVENT, handleWebviewZoom);
+    return () => window.removeEventListener(WEBVIEW_ZOOM_EVENT, handleWebviewZoom);
+  }, [instance.id]);
   
   const handleReload = () => {
     if (webviewRef.current && isVisible) {

--- a/src/components/workspace/AIToolView.tsx
+++ b/src/components/workspace/AIToolView.tsx
@@ -328,7 +328,7 @@ export const AIToolView = ({ tool, instance, isVisible, panelId }: AIToolViewPro
             allowpopups
             useragent={navigator.userAgent}
             title={tool.name}
-            webpreferences="contextIsolation=yes, nodeIntegration=no, nativeWindowOpen=yes"
+            webpreferences="contextIsolation=yes, nodeIntegration=no, nativeWindowOpen=yes, spellcheck=yes"
             partition="persist:webtool"
           />
         ) : (

--- a/src/components/workspace/Tab.tsx
+++ b/src/components/workspace/Tab.tsx
@@ -14,9 +14,10 @@ interface TabProps {
   isActive: boolean;
   onClose: () => void;
   panelId: number; // The current panel this tab is being displayed in
+  tabNumber: number;
 }
 
-export const Tab = ({ instance, tool, isActive, onClose, panelId }: TabProps) => {
+export const Tab = ({ instance, tool, isActive, onClose, panelId, tabNumber }: TabProps) => {
   const { setActivePanelTab, highlightPanel } = useAITools();
   const { settings } = useSettings();
   const [tabIconUrl, setTabIconUrl] = useState(tool.icon || getFaviconUrl(tool.url) || '');
@@ -120,6 +121,7 @@ export const Tab = ({ instance, tool, isActive, onClose, panelId }: TabProps) =>
 
         {/* Tab Title */}
         <span className="flex-1 truncate text-sm font-medium">
+          {settings.showTabNumbers && <span className="text-muted-foreground">{tabNumber}: </span>}
           {displayTitle}
         </span>
       </div>

--- a/src/components/workspace/TabBar.tsx
+++ b/src/components/workspace/TabBar.tsx
@@ -66,7 +66,7 @@ export const TabBar = ({ panelId, instances, activeInstanceId }: TabBarProps) =>
             items={instances.map(inst => inst.id)}
             strategy={horizontalListSortingStrategy}
           >
-            {instances.map((instance) => {
+            {instances.map((instance, index) => {
               const tool = getToolById(instance.toolId);
               if (!tool) return null;
 
@@ -78,6 +78,7 @@ export const TabBar = ({ panelId, instances, activeInstanceId }: TabBarProps) =>
                   isActive={instance.id === activeInstanceId}
                   onClose={() => closeToolInstance(instance.id)}
                   panelId={panelId}
+                  tabNumber={index + 1}
                 />
               );
             })}

--- a/src/context/AIToolsContext.tsx
+++ b/src/context/AIToolsContext.tsx
@@ -326,7 +326,13 @@ export const AIToolsProvider = ({ children }: { children: React.ReactNode }) => 
 
     setToolInstances(current => {
       const updated = current.filter(inst => inst.id !== instanceId);
-      return updated.map((inst, index) => ({ ...inst, position: index }));
+      return updated.map((inst, index) => ({
+        ...inst,
+        position: index,
+        positionInPanel: inst.panelId === instance.panelId && inst.positionInPanel > instance.positionInPanel
+          ? inst.positionInPanel - 1
+          : inst.positionInPanel,
+      }));
     });
     
     // Clean up activePanelTabs if the closed instance was active
@@ -334,17 +340,21 @@ export const AIToolsProvider = ({ children }: { children: React.ReactNode }) => 
       const updated = { ...current };
       // Check if this instance was active in any panel
       Object.keys(updated).forEach(pid => {
-        if (updated[parseInt(pid)] === instanceId) {
-          // Find another instance in this panel to activate
-          const remainingInstances = toolInstances
-            .filter(inst => inst.id !== instanceId && inst.panelId === parseInt(pid))
-            .sort((a, b) => a.positionInPanel - b.positionInPanel);
+        const panelId = parseInt(pid);
+        if (updated[panelId] === instanceId) {
+          const visibleInstances = (settings.syncedTabs
+            ? toolInstances
+            : toolInstances.filter(inst => inst.panelId === panelId)
+          ).sort((a, b) => settings.syncedTabs ? a.position - b.position : a.positionInPanel - b.positionInPanel);
+          const closedIndex = visibleInstances.findIndex(inst => inst.id === instanceId);
+          const remainingInstances = visibleInstances.filter(inst => inst.id !== instanceId);
           
           if (remainingInstances.length > 0) {
-            updated[parseInt(pid)] = remainingInstances[0].id;
+            const replacementIndex = Math.min(Math.max(closedIndex, 0), remainingInstances.length - 1);
+            updated[panelId] = remainingInstances[replacementIndex].id;
           } else {
             // No instances left in this panel, remove the active tab entry
-            delete updated[parseInt(pid)];
+            delete updated[panelId];
           }
         }
       });

--- a/src/context/AIToolsContext.tsx
+++ b/src/context/AIToolsContext.tsx
@@ -342,10 +342,10 @@ export const AIToolsProvider = ({ children }: { children: React.ReactNode }) => 
       Object.keys(updated).forEach(pid => {
         const panelId = parseInt(pid);
         if (updated[panelId] === instanceId) {
-          const visibleInstances = (settings.syncedTabs
+          const visibleInstances = [...(settings.syncedTabs
             ? toolInstances
             : toolInstances.filter(inst => inst.panelId === panelId)
-          ).sort((a, b) => settings.syncedTabs ? a.position - b.position : a.positionInPanel - b.positionInPanel);
+          )].sort((a, b) => settings.syncedTabs ? a.position - b.position : a.positionInPanel - b.positionInPanel);
           const closedIndex = visibleInstances.findIndex(inst => inst.id === instanceId);
           const remainingInstances = visibleInstances.filter(inst => inst.id !== instanceId);
           

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -14,6 +14,7 @@ interface Settings {
   defaultTools: string[];
   autoLayout: boolean;
   syncedTabs: boolean;
+  showTabNumbers: boolean;
 }
 
 interface SettingsContextType {
@@ -32,6 +33,7 @@ const defaultSettings: Settings = {
   defaultTools: ['chatgpt', 'gemini'],
   autoLayout: true,
   syncedTabs: false,
+  showTabNumbers: false,
 };
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -45,7 +47,8 @@ export const SettingsProvider = ({ children }: { children: React.ReactNode }) =>
     autostart: settings.autostart ?? false,
     defaultTools: settings.defaultTools ?? defaultSettings.defaultTools,
     autoLayout: (settings as any).autoLayout ?? true,
-    syncedTabs: (settings as any).syncedTabs ?? false
+    syncedTabs: (settings as any).syncedTabs ?? false,
+    showTabNumbers: (settings as any).showTabNumbers ?? false,
   };
 
   useEffect(() => {

--- a/src/context/ShortcutsContext.tsx
+++ b/src/context/ShortcutsContext.tsx
@@ -6,6 +6,7 @@ import {
   buildShortcutPreset,
   comboMatchesKeyboardEvent,
   combosEqual,
+  getBrowserZoomShortcutIdFromKeyboardEvent,
   getDefaultShortcutModifier,
   type ShortcutPreset,
   shortcutSequencesEqual,
@@ -248,6 +249,13 @@ export const ShortcutsProvider = ({ children }: { children: React.ReactNode }) =
         return;
       }
       if (recordingRef.current) return;
+
+      const browserZoomShortcutId = getBrowserZoomShortcutIdFromKeyboardEvent(event);
+      if (browserZoomShortcutId) {
+        event.preventDefault();
+        runActionById(browserZoomShortcutId, actionsRef, toolHotkeyActionsRef);
+        return;
+      }
 
       const activePrefix = activePrefixRef.current;
       if (activePrefix) {

--- a/src/hooks/useShortcutActions.ts
+++ b/src/hooks/useShortcutActions.ts
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useShortcuts } from '@/context/ShortcutsContext';
 import { useAITools } from '@/context/AIToolsContext';
 import { useSettings } from '@/context/SettingsContext';
+import { WEBVIEW_ZOOM_EVENT, type WebviewZoomAction } from '@/lib/webviewZoom';
 
 export const useShortcutActions = () => {
   const { registerAction, registerToolHotkeyAction, toolHotkeys } = useShortcuts();
@@ -26,6 +27,15 @@ export const useShortcutActions = () => {
 
   useEffect(() => {
     const visibleActivePanelId = activePanelId < parseInt(layout) ? activePanelId : 0;
+
+    /** Sends a browser zoom command to the active provider webview. */
+    const dispatchWebviewZoom = (action: WebviewZoomAction) => {
+      const activeInstance = getActivePanelInstance(visibleActivePanelId);
+      if (!activeInstance) return;
+      window.dispatchEvent(new CustomEvent(WEBVIEW_ZOOM_EVENT, {
+        detail: { instanceId: activeInstance.id, action },
+      }));
+    };
     
     registerAction('close-current-tool', () => {
       const activeInstance = getActivePanelInstance(visibleActivePanelId);
@@ -40,6 +50,16 @@ export const useShortcutActions = () => {
 
     registerAction('undo-close-tool', () => {
       restoreLastClosed();
+    });
+
+    registerAction('browser-zoom-in', () => {
+      dispatchWebviewZoom('in');
+    });
+    registerAction('browser-zoom-out', () => {
+      dispatchWebviewZoom('out');
+    });
+    registerAction('browser-zoom-reset', () => {
+      dispatchWebviewZoom('reset');
     });
 
     registerAction('layout-single', () => {

--- a/src/lib/shortcutUtils.ts
+++ b/src/lib/shortcutUtils.ts
@@ -17,6 +17,9 @@ const codeKeyLabels = new Map([
   ['Backquote', '`'],
   ['Minus', '-'],
   ['Equal', '='],
+  ['NumpadAdd', '+'],
+  ['NumpadSubtract', '-'],
+  ['NumpadEqual', '='],
   ['BracketLeft', '['],
   ['BracketRight', ']'],
   ['Backslash', '\\'],
@@ -77,6 +80,17 @@ export const comboFromKeyboardEvent = (event: KeyboardEvent): KeyCombo => {
   if (!isModifierKey(key)) keys.push(key);
 
   return keys;
+};
+
+/** Returns the browser zoom shortcut id for a keyboard event, if any. */
+export const getBrowserZoomShortcutIdFromKeyboardEvent = (event: KeyboardEvent) => {
+  const key = keyTokenFromKeyboardEvent(event);
+  const isPrimary = (event.ctrlKey || event.metaKey) && !event.altKey;
+  if (!isPrimary) return null;
+  if (key === '=' || key === '+') return 'browser-zoom-in';
+  if (!event.shiftKey && key === '-') return 'browser-zoom-out';
+  if (!event.shiftKey && key === '0') return 'browser-zoom-reset';
+  return null;
 };
 
 /** Checks whether a keyboard event matches a stored shortcut combo. */

--- a/src/lib/webviewZoom.ts
+++ b/src/lib/webviewZoom.ts
@@ -1,0 +1,19 @@
+export type WebviewZoomAction = 'in' | 'out' | 'reset';
+
+export const WEBVIEW_ZOOM_EVENT = 'ai-gate-webview-zoom';
+
+const WEBVIEW_ZOOM_FACTORS = [0.5, 0.67, 0.75, 0.8, 0.9, 1, 1.1, 1.25, 1.5, 1.75, 2, 2.5, 3];
+
+/** Returns the next browser-style zoom factor for a webview. */
+export const getNextWebviewZoomFactor = (currentZoom: number, action: WebviewZoomAction) => {
+  if (action === 'reset') return 1;
+
+  const nearestIndex = WEBVIEW_ZOOM_FACTORS.reduce((nearest, factor, index) => (
+    Math.abs(factor - currentZoom) < Math.abs(WEBVIEW_ZOOM_FACTORS[nearest] - currentZoom) ? index : nearest
+  ), 0);
+  const nextIndex = action === 'in'
+    ? Math.min(nearestIndex + 1, WEBVIEW_ZOOM_FACTORS.length - 1)
+    : Math.max(nearestIndex - 1, 0);
+
+  return WEBVIEW_ZOOM_FACTORS[nextIndex];
+};


### PR DESCRIPTION
## Summary

Adds browser-style zoom controls, optional tab numbering, better tab-close behavior, and several provider webview improvements. The goal is to make AI Gate feel closer to a normal browser shell for provider pages while preserving the tray-first desktop behavior.

## What Changed

### Browser-style zoom shortcuts

- Adds Cmd/Ctrl `+`, Cmd/Ctrl `-`, and Cmd/Ctrl `0` handling for the active provider webview.
- Applies zoom to the active tab only, using Chrome-like zoom steps.
- Handles shortcut input both from the app chrome and from focused Electron webviews, so zoom still works when focus is inside a provider page.
- Adds e2e coverage that verifies the zoom shortcut dispatches to the active tab.

### Optional tab numbering

- Adds a setting to prefix tabs with their visible position in the panel.
- Numbers are per panel when tabs are independent, and shared across panels when synced tabs are enabled.
- Updates settings copy to avoid implying the feature is limited to three tabs.

### Better tab close behavior

- Fixes closing an active middle tab so the adjacent tab becomes active instead of jumping back to the first tab.
- Keeps synced-tab sorting immutable when choosing the replacement tab.
- Adds e2e coverage for the adjacent-tab selection behavior.

### Explicit quit path

- Allows explicit app quit actions, including Cmd+Q and the tray Quit item, to fully quit the app.
- Window close still hides the app to the tray; this only fixes the explicit quit path.

### Provider webview media permissions and context menus

- Adds macOS microphone/camera usage descriptions and entitlements for provider pages that request voice or video input.
- Adds provider-session permission handlers that gate media requests on native macOS mic/camera access.
- Adds browser-like context menus to provider webviews through `electron-context-menu`.
- Enables spellcheck in the BrowserWindow and provider webviews.

## Why

Provider pages increasingly expose browser-native behavior such as zooming, context menus, spellcheck, voice input, and camera input. These changes make those provider pages behave more like they would in a regular browser while keeping AI Gate's multi-panel/tab workflow intact.

The tab-numbering and middle-tab-close fixes are aimed at keyboard-heavy workflows where visible tab order and predictable active-tab selection matter.

## Validation

- `npm run build`
- `npm run e2e -- e2e/shortcuts/panes.spec.ts`
- `npm run e2e:build`
- `npm run electron:build` to refresh the packaged mac app bundle
- Manual smoke test against the built `release-builds/mac-universal/AI Gate.app` for provider media permissions

## Notes for Reviewers

- Browser zoom shortcuts are intentionally treated as browser-standard shortcuts rather than user-configurable shortcuts in this PR.
- Media permission behavior is limited to preserving the working provider media path. A broader app-level per-origin permission UI was considered separately, but it caused repeated permission prompts and is not included here.
- Non-media provider permissions are denied by the installed provider-session handler; this PR focuses on media capture, context menus, and spellcheck.
