### PR TITLE
Fix macOS tray, update prompts, and provider link routing

### DIFF
--- a/e2e/system/popup-routing.spec.ts
+++ b/e2e/system/popup-routing.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { getProviderPopupRoute } from '../../electron/popupRouting';
+
+test('opens ordinary provider links in the external browser', () => {
+  expect(getProviderPopupRoute('https://support.google.com/chrome/answer/95346')).toBe('external');
+  expect(getProviderPopupRoute('https://example.com/articles/oauth-explained')).toBe('external');
+});
+
+test('keeps recognized sign-in popups inside AI Gate', () => {
+  const signInUrls = [
+    'https://accounts.google.com/o/oauth2/v2/auth?client_id=example',
+    'https://login.microsoftonline.com/common/oauth2/v2.0/authorize?client_id=example',
+    'https://github.com/login/oauth/authorize?client_id=example',
+    'https://appleid.apple.com/auth/authorize?client_id=example',
+    'https://auth.example.com/session/start',
+    'https://example.com/api/auth/signin/provider',
+  ];
+
+  for (const url of signInUrls) {
+    expect(getProviderPopupRoute(url)).toBe('in-app');
+  }
+});
+
+test('uses the OS handler for mail and denies unsupported popup schemes', () => {
+  expect(getProviderPopupRoute('mailto:help@example.com')).toBe('external');
+  expect(getProviderPopupRoute('javascript:alert(document.domain)')).toBe('deny');
+});

--- a/e2e/system/tray-harness.cjs
+++ b/e2e/system/tray-harness.cjs
@@ -1,0 +1,13 @@
+const { app, nativeImage } = require('electron');
+
+const trayIconModulePath = process.argv[2];
+const sourceIconPath = process.argv[3];
+
+app.whenReady().then(() => {
+  const { normalizeTrayIcon } = require(trayIconModulePath);
+  const sourceIcon = nativeImage.createFromPath(sourceIconPath);
+  const size = normalizeTrayIcon(sourceIcon, 'darwin').getSize();
+
+  process.stdout.write(`TRAY_SIZE:${JSON.stringify(size)}\n`);
+  app.quit();
+});

--- a/e2e/system/tray.spec.ts
+++ b/e2e/system/tray.spec.ts
@@ -1,0 +1,19 @@
+import { execFile } from 'node:child_process';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { test, expect } from '@playwright/test';
+
+const execFileAsync = promisify(execFile);
+
+test('normalizes the macOS tray image to menu bar dimensions', async () => {
+  const electronPath = require('electron') as string;
+  const { stdout } = await execFileAsync(electronPath, [
+    path.resolve('e2e/system/tray-harness.cjs'),
+    path.resolve('dist-electron/trayIcon.js'),
+    path.resolve('icons/png/favicon.png'),
+  ]);
+  const sizeLine = stdout.split('\n').find(line => line.startsWith('TRAY_SIZE:'));
+
+  expect(sizeLine).toBeDefined();
+  expect(JSON.parse(sizeLine!.slice('TRAY_SIZE:'.length))).toEqual({ width: 16, height: 16 });
+});

--- a/e2e/updates/popup.spec.ts
+++ b/e2e/updates/popup.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '../fixtures/electronApp';
+
+test('does not automatically reopen a dismissed release', async ({ appPage }) => {
+  await appPage.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+      if (url === 'https://api.github.com/repos/inulute/ai-gate/releases/latest') {
+        const version = localStorage.getItem('e2eLatestVersion');
+        return new Response(JSON.stringify({
+          tag_name: `v${version}`,
+          body: 'Release notes',
+          html_url: `https://github.com/inulute/ai-gate/releases/tag/v${version}`,
+          published_at: '2026-07-22T00:00:00Z',
+        }), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.startsWith('https://raw.githubusercontent.com/inulute/ai-gate/main/release_notes/')) {
+        return new Response('', { status: 404 });
+      }
+      return originalFetch(input, init);
+    };
+  });
+
+  await appPage.evaluate(() => {
+    localStorage.clear();
+    localStorage.setItem('e2eLatestVersion', '99.0.0');
+  });
+  await appPage.reload();
+
+  await expect(appPage.getByRole('heading', { name: 'Update Available!' })).toBeVisible();
+  await appPage.getByRole('button', { name: 'Close' }).click();
+  await appPage.reload();
+
+  await expect(appPage.getByRole('heading', { name: 'Update Available!' })).not.toBeVisible();
+  expect(await appPage.evaluate(() => localStorage.getItem('dismissedUpdateVersion'))).toBe('99.0.0');
+
+  await appPage.evaluate(() => localStorage.setItem('e2eLatestVersion', '99.0.1'));
+  await appPage.reload();
+
+  await expect(appPage.getByRole('heading', { name: 'Update Available!' })).toBeVisible();
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,6 +2,7 @@ const { app, BrowserWindow, session, shell, Menu, Tray, nativeImage, ipcMain, sy
 const path = require('path');
 const fs = require('fs');
 const { exec } = require('child_process');
+const { normalizeTrayIcon } = require('./trayIcon');
 
 const isDevelopment = !app.isPackaged;
 const isE2E = process.env.AI_GATE_E2E === '1';
@@ -666,15 +667,17 @@ function createTray() {
     icon = nativeImage.createFromBuffer(buffer, { width: size, height: size });
   }
   
+  const trayIcon = normalizeTrayIcon(icon);
+
   // Create the tray
-  tray = new Tray(icon);
+  tray = new Tray(trayIcon);
   
   // Force set the image again to ensure it's properly loaded
-  tray.setImage(icon);
+  tray.setImage(trayIcon);
   
   // Add some debugging
-  console.log('Tray created with icon size:', icon.getSize());
-  console.log('Tray icon is empty:', icon.isEmpty());
+  console.log('Tray created with icon size:', trayIcon.getSize());
+  console.log('Tray icon is empty:', trayIcon.isEmpty());
 
   // Create context menu for the tray
   const contextMenu = Menu.buildFromTemplate([

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,6 +2,7 @@ const { app, BrowserWindow, session, shell, Menu, Tray, nativeImage, ipcMain, sy
 const path = require('path');
 const fs = require('fs');
 const { exec } = require('child_process');
+const { ALLOWED_OPEN_SCHEMES, getProviderPopupRoute }: typeof import('./popupRouting') = require('./popupRouting');
 const { normalizeTrayIcon } = require('./trayIcon');
 
 const isDevelopment = !app.isPackaged;
@@ -116,8 +117,6 @@ const getPermissionOrigin = (url: string) => {
 const isMediaPermission = (permission: string) => {
   return ['media', 'audioCapture', 'videoCapture', 'microphone', 'camera'].includes(permission);
 };
-
-const ALLOWED_OPEN_SCHEMES = ['http:', 'https:', 'mailto:'];
 
 /** Returns the native macOS media types implied by an Electron permission request. */
 const getNativeMediaTypes = (permission: string, details: any): Array<'microphone' | 'camera'> => {
@@ -908,12 +907,9 @@ app.whenReady().then(async () => {
         if (ALLOWED_OPEN_SCHEMES.some(s => url.toLowerCase().startsWith(s))) shell.openExternal(url);
         return { action: 'deny' };
       }
-      // webview / OOPIF popups: only http/https open as in-app pop-up windows
-      // (via did-create-window confirmation). Other allowed schemes like mailto:
-      // must go to the OS handler, not a BrowserWindow that can't render them.
-      const lower = url.toLowerCase();
-      if (!lower.startsWith('http:') && !lower.startsWith('https:')) {
-        if (ALLOWED_OPEN_SCHEMES.some(s => lower.startsWith(s))) shell.openExternal(url);
+      const route = getProviderPopupRoute(url);
+      if (route !== 'in-app') {
+        if (route === 'external') shell.openExternal(url);
         return { action: 'deny' };
       }
       return {

--- a/electron/popupRouting.ts
+++ b/electron/popupRouting.ts
@@ -1,0 +1,40 @@
+export const ALLOWED_OPEN_SCHEMES = ['http:', 'https:', 'mailto:'];
+
+export type ProviderPopupRoute = 'external' | 'in-app' | 'deny';
+
+const AUTH_POPUP_HOSTS = new Set([
+  'accounts.google.com',
+  'appleid.apple.com',
+  'login.live.com',
+  'login.microsoftonline.com',
+]);
+
+const AUTH_HOST_LABELS = new Set(['accounts', 'auth', 'identity', 'login', 'signin']);
+const AUTH_PATH_SEGMENTS = new Set(['auth', 'authorize', 'authorization', 'login', 'oauth', 'oauth2', 'sign-in', 'signin']);
+
+/** Returns true when a web URL represents an authentication flow. */
+function isAuthPopupUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    const hostname = parsedUrl.hostname.toLowerCase();
+    const leadingHostLabel = hostname.split('.')[0];
+    const pathSegments = parsedUrl.pathname.toLowerCase().split('/').filter(Boolean);
+
+    return AUTH_POPUP_HOSTS.has(hostname)
+      || AUTH_HOST_LABELS.has(leadingHostLabel)
+      || pathSegments.some(segment => AUTH_PATH_SEGMENTS.has(segment));
+  } catch {
+    return false;
+  }
+}
+
+/** Returns where a provider webview pop-up should open. */
+export function getProviderPopupRoute(url: string): ProviderPopupRoute {
+  const lower = url.toLowerCase();
+
+  if (lower.startsWith('http:') || lower.startsWith('https:')) {
+    return isAuthPopupUrl(url) ? 'in-app' : 'external';
+  }
+
+  return ALLOWED_OPEN_SCHEMES.some(scheme => lower.startsWith(scheme)) ? 'external' : 'deny';
+}

--- a/electron/trayIcon.ts
+++ b/electron/trayIcon.ts
@@ -1,0 +1,9 @@
+import type { NativeImage } from 'electron';
+
+export function normalizeTrayIcon(icon: NativeImage, _platform = process.platform): NativeImage {
+  if (_platform !== 'darwin') {
+    return icon;
+  }
+
+  return icon.resize({ width: 16, height: 16, quality: 'best' });
+}

--- a/src/components/UpdatePopup.tsx
+++ b/src/components/UpdatePopup.tsx
@@ -21,10 +21,11 @@ import rehypeRaw from 'rehype-raw';
 interface UpdatePopupProps {
   isOpen: boolean;
   onClose: () => void;
+  onDismiss: () => void;
   releaseInfo: ReleaseInfo;
 }
 
-export const UpdatePopup = ({ isOpen, onClose, releaseInfo }: UpdatePopupProps) => {
+export const UpdatePopup = ({ isOpen, onClose, onDismiss, releaseInfo }: UpdatePopupProps) => {
   const [isOpening, setIsOpening] = useState(false);
   const { toast } = useToast();
 
@@ -39,6 +40,7 @@ export const UpdatePopup = ({ isOpen, onClose, releaseInfo }: UpdatePopupProps) 
         description: "The GitHub releases page has been opened in your browser.",
         duration: 3000
       });
+      onDismiss();
     } catch (error) {
       console.error('UpdatePopup: Error opening releases page:', error);
       const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
@@ -58,6 +60,7 @@ export const UpdatePopup = ({ isOpen, onClose, releaseInfo }: UpdatePopupProps) 
     tomorrow.setDate(tomorrow.getDate() + 1);
     tomorrow.setHours(9, 0, 0, 0);
     
+    localStorage.removeItem('dismissedUpdateVersion');
     localStorage.setItem('updateReminderTime', tomorrow.toISOString());
     onClose();
     
@@ -162,7 +165,7 @@ export const UpdatePopup = ({ isOpen, onClose, releaseInfo }: UpdatePopupProps) 
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onDismiss()}>
       <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden">
         <DialogHeader>
           <div className="flex items-center justify-between">

--- a/src/context/UpdateContext.tsx
+++ b/src/context/UpdateContext.tsx
@@ -3,6 +3,8 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { updateService, ReleaseInfo, UpdateCheckResult } from '@/services/updateService';
 import { UpdatePopup } from '@/components/UpdatePopup';
 
+const DISMISSED_UPDATE_VERSION_KEY = 'dismissedUpdateVersion';
+
 interface UpdateContextType {
   hasUpdate: boolean;
   releaseInfo: ReleaseInfo | null;
@@ -35,7 +37,7 @@ export const UpdateProvider = ({ children }: { children: React.ReactNode }) => {
             setShowPopup(true);
             localStorage.removeItem('updateReminderTime');
           }
-        } else {
+        } else if (localStorage.getItem(DISMISSED_UPDATE_VERSION_KEY) !== result.releaseInfo.version) {
           setShowPopup(true);
         }
       } else {
@@ -54,6 +56,14 @@ export const UpdateProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   const hideUpdatePopup = () => {
+    setShowPopup(false);
+  };
+
+  const dismissUpdatePopup = () => {
+    if (releaseInfo) {
+      localStorage.setItem(DISMISSED_UPDATE_VERSION_KEY, releaseInfo.version);
+    }
+    localStorage.removeItem('updateReminderTime');
     setShowPopup(false);
   };
 
@@ -81,6 +91,7 @@ export const UpdateProvider = ({ children }: { children: React.ReactNode }) => {
         <UpdatePopup
           isOpen={showPopup}
           onClose={hideUpdatePopup}
+          onDismiss={dismissUpdatePopup}
           releaseInfo={releaseInfo}
         />
       )}

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -17,6 +17,6 @@
     "types": ["electron"],
     "noEmit": false,
   },
-  "include": ["electron/main.ts"],
+  "include": ["electron/main.ts", "electron/trayIcon.ts"],
   "exclude": ["node_modules", "electron/preload.ts"]
 }

--- a/tsconfig.electron.json
+++ b/tsconfig.electron.json
@@ -17,6 +17,6 @@
     "types": ["electron"],
     "noEmit": false,
   },
-  "include": ["electron/main.ts", "electron/trayIcon.ts"],
+  "include": ["electron/main.ts", "electron/popupRouting.ts", "electron/trayIcon.ts"],
   "exclude": ["node_modules", "electron/preload.ts"]
 }


### PR DESCRIPTION
## What changed

- Resize the tray image to 16×16 on macOS before creating the Electron `Tray`, while leaving other platforms unchanged.
- Remember the version of an update dialog dismissed with Close or Go to Releases.
- Continue showing the sidebar update indicator, preserve Remind Tomorrow, and automatically prompt again when a newer release appears.
- Open ordinary HTTP/HTTPS links from provider webviews in the system browser while keeping recognized sign-in flows inside AI Gate with the shared provider session and existing confirmation dialog.
- Add Electron and renderer regressions for these behaviors.

## Why

AI Gate was passing its 1024×1024 PNG directly to the macOS status item. On affected systems, that created a 1040-point menu-bar window that displaced or hid other apps' status items. The update dialog also stored no state when dismissed, so the same release reopened on every launch.

Version 4.7.1 also routed every HTTP/HTTPS pop-up from a provider webview into a small AI Gate window. The broad rule was introduced for OAuth, but it also captured ordinary links that should open in the user's default browser. Routing now recognizes authentication hosts and path segments, keeping those flows in-app while sending other web links to the OS handler.

## Validation

- `npm run build`
- `npm run e2e` — 22 passed
- Targeted ESLint for the new popup routing module and tests
- Built and installed the signed universal 4.7.1 app on macOS; CoreGraphics reports a 32×24-point AI Gate status item on both displays instead of the previous 1040-point window.

## Existing lint failure

- `npm run lint` still fails on upstream `main` with 71 existing errors and 15 warnings; this change adds no new lint findings.
